### PR TITLE
feat: Add community membership method and modify accessibility of methods

### DIFF
--- a/contracts/PodCastNFT.sol
+++ b/contracts/PodCastNFT.sol
@@ -26,7 +26,7 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
 
     function _communityMember(uint256 _tokenId) internal view returns (string memory) {
       if (isCommunityMember(_tokenId)) {
-        return "henkaku community member";
+        return "Henkaku community member";
       }
       return "N/A";
     }

--- a/contracts/PodCastNFT.sol
+++ b/contracts/PodCastNFT.sol
@@ -24,13 +24,6 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
       return _communityMemberShip[_tokenId];
     }
 
-    function _communityMember(uint256 _tokenId) internal view returns (string memory) {
-      if (isCommunityMember(_tokenId)) {
-        return "Henkaku community member";
-      }
-      return "N/A";
-    }
-
     function updateNFT(
         uint256 tokenId,
         string memory _imageURI,
@@ -66,34 +59,36 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
         string memory _role,
         string memory _point
     ) internal view returns (string memory) {
+        string memory _name = "Membership NFT";
+        string memory _description = "The membership card of this Henkaku community represents the contribution of the podcast.\\n\\n"
+          "**Special thanks**\\n\\n"
+          "NFT Design:\\n\\n"
+          "Digital Garage team\\n\\n"
+          "Yukinori Hidaka, Saoti Yamaguchi, Masaaki Tsuji, Yuki Sakai, Yuko Hidaka, Masako Inoue, Nanami Nishio, Ruca Takei, Ryu Hayashi.\\n\\n"
+          "Engineering:\\n\\n"
+          "isbtty, yasek, geeknees";
+
+        bytes memory _attributes;
+        if (isCommunityMember(_tokenId)) {
+          _attributes = abi.encodePacked(
+            '"attributes": [{"trait_type": "Role", "value": "', _role, '"},',
+            '{"trait_type": "Henkaku Community member", "value": "Henkaku Community Member"},',
+            '{"display_type": "number", "trait_type": "Point", "value": "', _point, '"}]'
+          );
+        } else {
+          _attributes = abi.encodePacked(
+            '"attributes": [{"trait_type": "Role", "value": "', _role, '"},',
+            '{"display_type": "number", "trait_type": "Point", "value": "', _point, '"}]'
+          );
+        }
+
         string memory json = Base64.encode(
-            bytes(
-                string(
-                    abi.encodePacked(
-                        '{"name": ',
-                        '"Membership NFT",',
-                        '"description": ',
-                        '"The membership card of this Henkaku community represents the contribution of the podcast.\\n\\n',
-                        "**Special thanks**\\n\\n",
-                        "NFT Design:\\n\\n",
-                        "Digital Garage team\\n\\n",
-                        "Yukinori Hidaka, Saoti Yamaguchi, Masaaki Tsuji, Yuki Sakai, Yuko Hidaka, Masako Inoue, Nanami Nishio, Ruca Takei, Ryu Hayashi.\\n\\n",
-                        "Engineering:\\n\\n",
-                        'isbtty, yasek, geeknees",',
-                        '"image": "',
-                        _imageURI,
-                        '",',
-                        '"attributes": [',
-                        '{"trait_type": "Role", "value": "',
-                        _role,
-                        '"},',
-                        '{"trait_type": "Henkaku Community member", "value": "',
-                        _communityMember(_tokenId),
-                        '"},{"display_type": "number", "trait_type": "Point", "value": "',
-                        _point,
-                        '"}]}'
-                    )
-                )
+            abi.encodePacked(
+                '{"name": "', _name, '",'
+                '"description": "', _description, '",'
+                '"image": "', _imageURI, '",',
+                string(_attributes),
+                "}"
             )
         );
         return string(abi.encodePacked("data:application/json;base64,", json));

--- a/contracts/PodCastNFT.sol
+++ b/contracts/PodCastNFT.sol
@@ -113,7 +113,7 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
         );
         require(
           balanceOf(_to) == 0,
-          "User have had already a memebrship NFT"
+          "User has had already a memebrship NFT"
         );
 
         _tokenIds.increment();

--- a/contracts/PodCastNFT.sol
+++ b/contracts/PodCastNFT.sol
@@ -20,23 +20,28 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
 
     mapping(uint256 => bool) private _communityMemberShip;
 
-    function isCommunityMember(uint256 _tokenId) public view returns(bool){
+    function isCommunityMember(uint256 _tokenId) public view returns(bool) {
       return _communityMemberShip[_tokenId];
+    }
+
+    function isCommunityMemberByCommunityRole(string memory _roleInCommunity) internal view returns(bool) {
+      return bytes(_roleInCommunity).length > 2;
     }
 
     function updateNFT(
         uint256 tokenId,
         string memory _imageURI,
         string memory _role,
-        bool _isCommunityMember,
+        string memory _roleInCommunity,
         string memory _point
     ) public {
         require(
             hasRole(ADMIN_ROLE, msg.sender),
             "You are not authorized to update nft"
         );
-        string memory finalTokenUri = getTokenURI(tokenId, _imageURI, _role, _point);
-        _communityMemberShip[tokenId] = _isCommunityMember;
+
+        _communityMemberShip[tokenId] = isCommunityMemberByCommunityRole(_roleInCommunity);
+        string memory finalTokenUri = getTokenURI(tokenId, _imageURI, _role, _roleInCommunity, _point);
         _setTokenURI(tokenId, finalTokenUri);
     }
 
@@ -57,6 +62,7 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
         uint256 _tokenId,
         string memory _imageURI,
         string memory _role,
+        string memory _roleInCommunity,
         string memory _point
     ) internal view returns (string memory) {
         string memory _name = "Membership NFT";
@@ -72,7 +78,7 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
         if (isCommunityMember(_tokenId)) {
           _attributes = abi.encodePacked(
             '"attributes": [{"trait_type": "Role", "value": "', _role, '"},',
-            '{"trait_type": "Henkaku Community member", "value": "Henkaku Community Member"},',
+            '{"trait_type": "Henkaku Community member", "value": "', _roleInCommunity, '"},',
             '{"display_type": "number", "trait_type": "Point", "value": "', _point, '"}]'
           );
         } else {
@@ -97,8 +103,8 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
     function mint(
         string memory _imageURI,
         string memory _role,
+        string memory _roleInCommunity,
         string memory _point,
-        bool _isCommunityMember,
         address _to
     ) public returns (uint256) {
         require(
@@ -110,8 +116,8 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
         uint256 newItemId = _tokenIds.current();
         _safeMint(_to, newItemId);
 
-        _communityMemberShip[newItemId] = _isCommunityMember;
-        string memory finalTokenUri = getTokenURI(newItemId, _imageURI, _role, _point);
+        _communityMemberShip[newItemId] = isCommunityMemberByCommunityRole(_roleInCommunity);
+        string memory finalTokenUri = getTokenURI(newItemId, _imageURI, _role, _roleInCommunity, _point);
         _setTokenURI(newItemId, finalTokenUri);
 
         return newItemId;

--- a/contracts/PodCastNFT.sol
+++ b/contracts/PodCastNFT.sol
@@ -111,6 +111,10 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
             hasRole(ADMIN_ROLE, msg.sender),
             "You are not authorized to mint"
         );
+        require(
+          balanceOf(_to) == 0,
+          "User have had already a memebrship NFT"
+        );
 
         _tokenIds.increment();
         uint256 newItemId = _tokenIds.current();

--- a/contracts/PodCastNFT.sol
+++ b/contracts/PodCastNFT.sol
@@ -24,7 +24,7 @@ contract PodCastNFT is ERC721URIStorage, Ownable, ConsensusAdminable {
       return _communityMemberShip[_tokenId];
     }
 
-    function isCommunityMemberByCommunityRole(string memory _roleInCommunity) internal view returns(bool) {
+    function isCommunityMemberByCommunityRole(string memory _roleInCommunity) internal pure returns(bool) {
       return bytes(_roleInCommunity).length > 2;
     }
 

--- a/scripts/mint.js
+++ b/scripts/mint.js
@@ -17,14 +17,6 @@ const main = async () => {
   );
   await tx.wait();
 
-  const tx = await contract.mint(
-    "https://dl.dropboxusercontent.com/s/ifuvt9h1spilofh/QmW2AHtZWdeE73ae73PkexAHDboisuZiyB8hGJtyXn5bCn.png",
-    "Henkaku Master",
-    "",
-    "10000",
-    owner.address
-  );
-
   await tx.wait();
   const user = await contract.ownerOf(1);
   console.log("Owner:", user);

--- a/scripts/mint.js
+++ b/scripts/mint.js
@@ -12,6 +12,7 @@ const main = async () => {
     "https://dl.dropboxusercontent.com/s/ifuvt9h1spilofh/QmW2AHtZWdeE73ae73PkexAHDboisuZiyB8hGJtyXn5bCn.png",
     "Henkaku Master",
     "10000",
+    true,
     owner.address
   );
   await tx.wait();

--- a/scripts/mint.js
+++ b/scripts/mint.js
@@ -17,7 +17,6 @@ const main = async () => {
   );
   await tx.wait();
 
-  await tx.wait();
   const user = await contract.ownerOf(1);
   console.log("Owner:", user);
   const uri = await contract.tokenURI(1);

--- a/scripts/mint.js
+++ b/scripts/mint.js
@@ -11,12 +11,21 @@ const main = async () => {
   const tx = await contract.mint(
     "https://dl.dropboxusercontent.com/s/ifuvt9h1spilofh/QmW2AHtZWdeE73ae73PkexAHDboisuZiyB8hGJtyXn5bCn.png",
     "Henkaku Master",
+    "Henkaku Community Member",
     "10000",
-    true,
     owner.address
   );
   await tx.wait();
 
+  const tx = await contract.mint(
+    "https://dl.dropboxusercontent.com/s/ifuvt9h1spilofh/QmW2AHtZWdeE73ae73PkexAHDboisuZiyB8hGJtyXn5bCn.png",
+    "Henkaku Master",
+    "",
+    "10000",
+    owner.address
+  );
+
+  await tx.wait();
   const user = await contract.ownerOf(1);
   console.log("Owner:", user);
   const uri = await contract.tokenURI(1);

--- a/scripts/update.js
+++ b/scripts/update.js
@@ -11,7 +11,8 @@ const main = async () => {
   const tx1 = await contract.mintAndTransfer(
     "https://dl.dropboxusercontent.com/s/ifuvt9h1spilofh/QmW2AHtZWdeE73ae73PkexAHDboisuZiyB8hGJtyXn5bCn.png",
     "Henkaku Master",
-    "10000"
+    "",
+    "10000",
     owner.address
   );
   await tx1.wait();
@@ -25,6 +26,7 @@ const main = async () => {
     1,
     "https://dl.dropboxusercontent.com/s/svwstwur6kqdaib/DmW2AHtZWdeE73ae73PkexAHDboisuZiyB8hGJtyXn5bCn.png",
     "Henkaku King",
+    "member",
     "100000000"
   );
   await tx2.wait();

--- a/test/mint.js
+++ b/test/mint.js
@@ -18,11 +18,37 @@ describe("PodCastNFT free mint", function () {
 
     const mintTx = await contract.mint(
       "https://example.com/podcast.png",
-      "Henkaku Master",
+      "Podcast Contributor",
+      true,
       "10000",
       user1.address
     );
     await mintTx.wait();
     expect(await contract.ownerOf(1)).to.be.equal(user1.address);
+  });
+
+  it("users have community Membership", async function () {
+    const [owner, user1, user2] = await ethers.getSigners();
+    contract = await Contract.deploy([owner.address], false);
+    await contract.deployed();
+
+    let mintTx = await contract.mint(
+      "https://example.com/podcast.png",
+      "Podcast Contributor",
+      true,
+      "10000",
+      user1.address
+    );
+    await mintTx.wait();
+
+    mintTx = await contract.mint(
+      "https://example.com/podcast.png",
+      "Podcast Contributor",
+      false,
+      "10000",
+      user1.address
+    );
+    await mintTx.wait();
+    expect(await contract.isCommunityMember(2)).to.be.equal(true);
   });
 });

--- a/test/mint.js
+++ b/test/mint.js
@@ -19,7 +19,7 @@ describe("PodCastNFT free mint", function () {
     const mintTx = await contract.mint(
       "https://example.com/podcast.png",
       "Podcast Contributor",
-      true,
+      "",
       "10000",
       user1.address
     );
@@ -35,7 +35,7 @@ describe("PodCastNFT free mint", function () {
     let mintTx = await contract.mint(
       "https://example.com/podcast.png",
       "Podcast Contributor",
-      true,
+      "",
       "10000",
       user1.address
     );
@@ -44,11 +44,13 @@ describe("PodCastNFT free mint", function () {
     mintTx = await contract.mint(
       "https://example.com/podcast.png",
       "Podcast Contributor",
-      false,
+      "Henkaku Community Member",
       "10000",
       user1.address
     );
     await mintTx.wait();
+
+    expect(await contract.isCommunityMember(1)).to.be.equal(false);
     expect(await contract.isCommunityMember(2)).to.be.equal(true);
   });
 });

--- a/test/mint.js
+++ b/test/mint.js
@@ -46,11 +46,36 @@ describe("PodCastNFT free mint", function () {
       "Podcast Contributor",
       "Henkaku Community Member",
       "10000",
-      user1.address
+      user2.address
     );
     await mintTx.wait();
 
     expect(await contract.isCommunityMember(1)).to.be.equal(false);
     expect(await contract.isCommunityMember(2)).to.be.equal(true);
+  });
+
+  it("cannot mint twice for the same user(owner)", async function () {
+    const [owner, user1] = await ethers.getSigners();
+    contract = await Contract.deploy([owner.address], false);
+    await contract.deployed();
+
+    const mintTx = await contract.mint(
+      "https://example.com/podcast.png",
+      "Podcast Contributor",
+      "",
+      "10000",
+      user1.address
+    );
+    await mintTx.wait();
+
+    await expect(
+        contract.mint(
+          "https://example.com/podcast.png",
+          "Podcast Contributor",
+          "epic",
+          "10000",
+          user1.address
+        )
+    ).eventually.to.rejectedWith(Error)
   });
 });


### PR DESCRIPTION
## 目的
- henkakuのcommunityに属しているかをmembership NFTに付与する
- そうすることで、今後henkakuのcommunity memberに対してのAuthを可能とさせる

## 実装したもの
- membershipがあるかを判別する機能の実装
- membershipの付与機能
- methodsのaccessibilityの変更
- mintは一回のみに変更

## testnet
- https://testnets.opensea.io/assets/0xb384c2edc1f4d54137ba8bab6c9126769bde0bdc/1

<img width="548" alt="image" src="https://user-images.githubusercontent.com/4782857/156865947-f3c1fb0f-0ace-4325-b2b3-89b5956ca69e.png">

## test

```js
  PodCastNFT free mint
    ✓ can mint for admin (239ms)
    ✓ users have community Membership (268ms)
    ✓ cannot mint twice for the same user(owner) (147ms)
```