### PR TITLE
Add burn function

### DIFF
--- a/contracts/PodCastNFT.sol
+++ b/contracts/PodCastNFT.sol
@@ -129,7 +129,7 @@ contract PodCastNFT is ERC721URIStorage, Ownable {
         string memory _point,
         address _to
     ) public onlyOwner returns (uint256) {
-        require(balanceOf(_to) == 0, "User has had already a memebrship NFT");
+        require(balanceOf(_to) == 0, "User has had already a membership NFT");
 
         _tokenIds.increment();
         uint256 newItemId = _tokenIds.current();
@@ -144,5 +144,12 @@ contract PodCastNFT is ERC721URIStorage, Ownable {
         );
         _setTokenURI(newItemId, finalTokenUri);
         return newItemId;
+    }
+
+    function burn(
+        uint256 _tokenId
+    ) public onlyOwner {
+        require(getRoles(ownerOf(_tokenId)).length == 0, "membership nft is still owned by member");
+        _burn(_tokenId);
     }
 }

--- a/test/mint.js
+++ b/test/mint.js
@@ -141,4 +141,41 @@ describe('PodCastNFT', function () {
       )
     ).eventually.to.rejectedWith(Error)
   })
+
+  describe('burn', () => {
+    it('can burn for admin', async () => {
+      const mintTx = await contract.mint(
+          'https://example.com/podcast.png',
+          ['Podcast Contributor'],
+          '10000',
+          owner.address
+      )
+      await mintTx.wait()
+
+      const transferTx = await contract['safeTransferFrom(address,address,uint256)'](
+          owner.address,
+          alice.address,
+          1
+      )
+      await transferTx.wait()
+
+      const burnTx = await contract.burn(1)
+      await burnTx.wait()
+
+      await expect(contract.ownerOf(1)).to.be.revertedWith( 'ERC721: owner query for nonexistent token')
+    })
+    it('cannot burn owned nft', async () => {
+      const mintTx = await contract.mint(
+          'https://example.com/podcast.png',
+          ['Podcast Contributor'],
+          '10000',
+          owner.address
+      )
+      await mintTx.wait()
+
+      await expect(
+          contract.burn(1)
+      ).to.be.revertedWith('membership nft is still owned by member')
+    })
+  })
 })


### PR DESCRIPTION
# object
* To be able to have admins burn membership NFT when it is passed to someone outside the community.

# spec
```
    burn
      ✓ can burn for admin
      ✓ cannot burn owned nft
```